### PR TITLE
Some random fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "glob": "^7.1.6",
     "hubot-conversation": "^1.1.1",
     "request": "^2.88.2",
-    "sharp": "^0.25.4",
-    "slack": "^11.0.2"
+    "sharp": "^0.25.4"
   },
   "peerDependencies": {
     "hubot": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emojme-hubot-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "a hubot script to run emojme tasks from slack",
   "main": "index.coffee",
   "scripts": {},

--- a/src/commands.coffee
+++ b/src/commands.coffee
@@ -46,9 +46,9 @@ Hey there! emojme is an project made to interface with the dark parts of slack's
 
 In order to do anything with it here, you'll need to make sure that hubot knows about your list of emoji, which you can check on with `emojme status`.
 
-If there is no emoji cache or it's out of date, you can fix that with `@hubot emojme refresh`, that'll lead you by the hand to getting a cookie and a token and updating the list of emoji that I know about. There will be a 60 second time window to enter your cookie and token, so get a head start by checking out the docs [on the emojme repo](https://github.com/jackellenberger/emojme#finding-a-slack-token)
+If there is no emoji cache or it's out of date, you can fix that with `@hubot emojme refresh`, that'll lead you by the hand to getting a cookie and a token and updating the list of emoji that I know about. There will be a 60 second time window to enter your cookie and token, so get a head start by checking out the docs <https://github.com/jackellenberger/emojme#finding-a-slack-token|on the emojme repo>
 
-Questions, comments, concerns? Ask em either on emojme, or on [this project](https://github.com/jackellenberger/emojme-hubot-plugin), whatever's relevant.
+Questions, comments, concerns? Ask em either on emojme, or on <https://github.com/jackellenberger/emojme-hubot-plugin|this project>, whatever's relevant.
 """)
 
 
@@ -75,7 +75,7 @@ Questions, comments, concerns? Ask em either on emojme, or on [this project](htt
     authJsonString = authResponse.match[1].trim()
     try
       authJson = JSON.parse(authJsonString)
-      token = authJson["domain"] || authJson["subdomain"]
+      subdomain = authJson["domain"] || authJson["subdomain"]
       token = authJson["token"]
       cookie = authJson["cookie"]
       if subdomain and token and cookie

--- a/src/commands.coffee
+++ b/src/commands.coffee
@@ -52,7 +52,7 @@ Questions, comments, concerns? Ask em either on emojme, or on <https://github.co
 
 
   robot.hear /{.*xoxc-\d{13}-\d{13}-\d{13}-\w{64}.*}/i, (request) ->
-    authJsonString = request.match[0]
+    authJsonString = request.match[0].replace(/[“”]/g, '"')
     util.ensure_no_public_tokens request, authJsonString
 
   robot.respond /emojme (?:forget|clear|expire) my (?:login|credentials|creds|auth|password|token)/i, (request) ->

--- a/src/commands.coffee
+++ b/src/commands.coffee
@@ -30,7 +30,6 @@
 #
 # Author:
 #   Jack Ellenberger <jellenberger@uchicago.edu>
-slack = require 'slack'
 Conversation = require 'hubot-conversation'
 chrono = require('chrono-node')
 
@@ -52,9 +51,9 @@ Questions, comments, concerns? Ask em either on emojme, or on <https://github.co
 """)
 
 
-  robot.respond /(emojme|token).*(xoxs-\d{12}-\d{12}-\d{12}-\w{64})/i, (request) ->
-    token = request.match[1]
-    util.ensure_no_public_tokens request, token
+  robot.hear /{.*xoxc-\d{13}-\d{13}-\d{13}-\w{64}.*}/i, (request) ->
+    authJsonString = request.match[0]
+    util.ensure_no_public_tokens request, authJsonString
 
   robot.respond /emojme (?:forget|clear|expire) my (?:login|credentials|creds|auth|password|token)/i, (request) ->
     util.expire_user_auth request.envelope.user.id

--- a/src/commands.coffee
+++ b/src/commands.coffee
@@ -61,7 +61,7 @@ Questions, comments, concerns? Ask em either on emojme, or on <https://github.co
 
   robot.respond /emojme status/i, (request) ->
     util.require_cache request, (emojiList, lastUser, lastRefresh) ->
-      request.send("#{lastUser} last refreshed the emoji list back at #{Date(lastRefresh).toString()} when there were #{emojiList.length} emoji")
+      request.send("#{lastUser} last refreshed the emoji list back at #{new Date(lastRefresh)} when there were #{emojiList.length} emoji")
 
   robot.respond /emojme refresh$/i, (request) ->
     util.react request, "stand-by"

--- a/src/legacy-commands.coffee
+++ b/src/legacy-commands.coffee
@@ -6,17 +6,17 @@
 # Author:
 #   Jack Ellenberger <jellenberger@uchicago.edu>
 emojme = require 'emojme'
-slack = require 'slack'
+# slack = require 'slack'
 
 module.exports = (robot) ->
   robot.respond /emojme how do/i, (context) ->
     context.send("""
-Hey! [emojme](https://github.com/jackellenberger/emojme) is a project to mess with slack emoji.
+Hey! <https://github.com/jackellenberger/emojme|emojme> is a project to mess with slack emoji.
 In order to do anything with it here, you'll need to make sure that hubot knows about your emoji, which you can check on with `emojme status`.
 If there is no emoji cache or it's out of date, create a DM with hubot and write the following command:
   `emojme refresh with my super secret info that i will not post in any public channels: <YOUR AUTH JSON>`
 
-`<YOUR JSON>` is a combination of slack domain, cookie token, and cookie, all of which need to be grabbed from a logged in slack web page. This information is intentionally short-lived, so use it while you can!. [Find out how to find your auth info here](https://github.com/jackellenberger/emojme#finding-a-slack-token), but the easiest way is via the [Emojme Chrome Extension](https://chrome.google.com/webstore/detail/emojme-emoji-anywhere/nbnaglaclijdfidbinlcnfdbikpbdkog?hl=en-US).
+`<YOUR JSON>` is a combination of slack domain, cookie token, and cookie, all of which need to be grabbed from a logged in slack web page. This information is intentionally short-lived, so use it while you can!. <https://github.com/jackellenberger/emojme#finding-a-slack-token|Find out how to find your auth info here>, but the easiest way is via the <https://chrome.google.com/webstore/detail/emojme-emoji-anywhere/nbnaglaclijdfidbinlcnfdbikpbdkog?hl=en-US|Emojme Chrome Extension>.
 """)
 
 # Superceded by /emojme refresh with .*/

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -108,7 +108,7 @@ module.exports = (robot) ->
     team_id = request.envelope.user.slack.team_id || request.message.user.slack.team_id || process.env.SLACK_TEAM_ID
     self.expire_user_auth user_id
     dialog = robot.emojmeConversation.startDialog request, 300000 # I know this isn't 60 seconds it's a joke
-    robot.send {room: user_id}, "Hey #{request.envelope.user.name}, in order to do what you've asked I'm gonna need a bit of authentication. Use the Emojme Chrome Extension]() to collect an auth blob, or read about how to collect your own [token](https://github.com/jackellenberger/emojme#finding-a-slack-token) and [cookie](https://github.com/jackellenberger/emojme#finding-a-slack-cookie). What I'm looking for is a json string, something like, `{\"token\":\"xoxc-...\",\"cookie\":\"long-inscrutible-string\"}` Just send that alone as message, please."
+    robot.send {room: user_id}, "Hey #{request.envelope.user.name}, in order to do what you've asked I'm gonna need a bit of authentication. Use the <https://chrome.google.com/webstore/detail/emojme-emoji-anywhere/nbnaglaclijdfidbinlcnfdbikpbdkog|Emojme Chrome Extension> to collect an auth blob, or read about how to collect your own <https://github.com/jackellenberger/emojme#finding-a-slack-token|token> and <https://github.com/jackellenberger/emojme#finding-a-slack-cookie|cookie>. What I'm looking for is a json string, something like, `{\"token\":\"xoxc-...\",\"cookie\":\"long-inscrutible-string\"}` Just send that alone as message, please."
     dialog.addChoice /({.*})/i, (authResponse) ->
       subdomain = request.message.user.slack.team_id.replace(/:/g,'').trim()
       authJsonString = authResponse.match[0].trim()
@@ -157,7 +157,7 @@ module.exports = (robot) ->
     self = this
     self.readAdminList (emojiList) ->
       if (
-        (emojiList = robot.brain.get 'emojme.AdminList' ) &&
+        (emojiList) &&
         (lastUser = robot.brain.get 'emojme.AuthUser' ) &&
         (lastRefresh = robot.brain.get 'emojme.LastUpdatedAt' )
       )

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -123,9 +123,9 @@ module.exports = (robot) ->
     self.expire_user_auth user_id
     dialog = robot.emojmeConversation.startDialog request, 300000 # I know this isn't 60 seconds it's a joke
     robot.send {room: user_id}, "Hey #{request.envelope.user.name}, in order to do what you've asked I'm gonna need a bit of authentication. Use the <https://chrome.google.com/webstore/detail/emojme-emoji-anywhere/nbnaglaclijdfidbinlcnfdbikpbdkog|Emojme Chrome Extension> to collect an auth blob, or read about how to collect your own <https://github.com/jackellenberger/emojme#finding-a-slack-token|token> and <https://github.com/jackellenberger/emojme#finding-a-slack-cookie|cookie>. What I'm looking for is a json string, something like, `{\"token\":\"xoxc-...\",\"cookie\":\"long-inscrutible-string\"}` Just send that alone as message, please."
-    dialog.addChoice /({.*})/i, (authResponse) ->
+    dialog.addChoice /{.*}/i, (authResponse) ->
       subdomain = request.message.user.slack.team_id.replace(/:/g,'').trim()
-      authJsonString = authResponse.match[0].trim()
+      authJsonString = authResponse.match[0].replace(/[“”]/g, '"').trim()
 
       try
         authJson = JSON.parse(authJsonString)


### PR DESCRIPTION
Some things I noticed since my last changes
- Links now format properly since slack decided to invent their own markdown format
- The token detecting and deleting from public channels has been reworked to work with cookies
- I tried to paste my json blob in on a mac and slack formatted my quote to curly quotes so I made a change to accept them anyway
- `emojme status` now returns `lastRefresh` as the correct time instead of the current time