### PR TITLE
Fix User Loading and undefined subdomain on refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emojme-hubot-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a hubot script to run emojme tasks from slack",
   "main": "index.coffee",
   "scripts": {},
@@ -15,7 +15,7 @@
     "emoji"
   ],
   "engines": {
-    "node": "10.x"
+    "node": ">12.13.0"
   },
   "author": "Jack Ellenberger <jellenberger@uchicago.edu>",
   "license": "ISC",


### PR DESCRIPTION
`request.message.user.slack` sometimes returns undefined if the user hasn't been loaded in the brain yet, causing an error when trying to get the slack subdomain

- `get_slack_user` calls the slack client's `fetchUser` which will load them into the brain
- and just in case this still doesn't work, just grab the subdomain from the authJson because it's there and why not

this should probably fix issues with disabling user sync, but I can't test it locally for some reason